### PR TITLE
Support nil value as NULL

### DIFF
--- a/holycorn.c
+++ b/holycorn.c
@@ -298,8 +298,10 @@ static TupleTableSlot * rbIterateForeignScan(ForeignScanState *node) {
             slot->tts_isnull[i] = true;
             break;
           case MRB_TT_FALSE: //TODO: use BoolGetDatum
-            slot->tts_isnull[i] = true;
-            slot->tts_values[i] = BoolGetDatum(false);
+            if (!mrb_nil_p(column)) {
+                slot->tts_isnull[i] = true;
+                slot->tts_values[i] = BoolGetDatum(false);
+            }
             break;
           case MRB_TT_TRUE:
             slot->tts_isnull[i] = false;


### PR DESCRIPTION
MRB_TT_FALSE holds both false and nil values. 
I added a check for nil value.,If column it is not nil - it is boolean false value. 

Not sure if slot->tts_isnull[i] = true; should still be true.
