### PR TITLE
Now only supports PG 9.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All the following wrappers are currently linked against Holycorn:
 
 ### Prerequisites
 
-* PostgreSQL 9.1+
+* PostgreSQL 9.4+
 
 ### Setup
 


### PR DESCRIPTION
This commits updates the README so it reflects better what versions are
officially supported.  There used to be no test infrastructure
whatsoever with Holycorn but now there are builds for each one of the
supported versions, it made sense to announce PG 9.1, 9.2 and 9.3 are
not supported anymore.