### PR TITLE
Add support for `IMPORT FOREIGN SCHEMA`

### DIFF
--- a/builtin_wrappers/holycorn-redis/mrblib/holycorn-redis.rb
+++ b/builtin_wrappers/holycorn-redis/mrblib/holycorn-redis.rb
@@ -20,5 +20,20 @@ class HolycornRedis
       nil
     end
   end
+
+  def self.import_schema(args)
+<<-SCHEMA
+	CREATE FOREIGN TABLE #{args['local_schema']}.#{args['prefix']}redis_table
+        ( key text
+        , value text
+        )
+	SERVER #{args['server_name']}
+	OPTIONS ( wrapper_class 'HolycornRedis'
+	        , host '#{args['host']}'
+	        , port '#{args['port']}'
+	        , db '#{args['db']}'
+	);
+SCHEMA
+  end
   self
 end

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,6 +10,7 @@ redis-cli < tests/redis.commands
 
 # Setup Postgres
 exec_psql /holycorn/tests/setup.sql
+exec_psql /holycorn/tests/setups/$1.sql
 exec_psql /holycorn/tests/run.sql
 
 # Execute tests

--- a/tests/run.sql
+++ b/tests/run.sql
@@ -3,6 +3,6 @@ SELECT
    key
  , value
 FROM
-  redis_table
+  holycorn_tables.holycorn_redis_table
 ORDER BY
   key

--- a/tests/setup.sql
+++ b/tests/setup.sql
@@ -1,15 +1,4 @@
 CREATE EXTENSION holycorn;
+CREATE SCHEMA holycorn_tables;
 CREATE SERVER holycorn_server
   FOREIGN DATA WRAPPER holycorn;
-CREATE FOREIGN TABLE redis_table
-  (
-      key text
-    , value text
-  )
-  SERVER holycorn_server
-  OPTIONS (
-      wrapper_class 'HolycornRedis'
-    , host '127.0.0.1'
-    , port '6379'
-    , db '0'
-  );

--- a/tests/setups/10.sql
+++ b/tests/setups/10.sql
@@ -1,0 +1,9 @@
+IMPORT FOREIGN SCHEMA holycorn_schema
+FROM SERVER holycorn_server
+INTO holycorn_tables
+OPTIONS ( wrapper_class 'HolycornRedis'
+        , host '127.0.0.1'
+        , port '6379'
+        , db '0'
+        , prefix 'holycorn_'
+        );

--- a/tests/setups/11.sql
+++ b/tests/setups/11.sql
@@ -1,0 +1,9 @@
+IMPORT FOREIGN SCHEMA holycorn_schema
+FROM SERVER holycorn_server
+INTO holycorn_tables
+OPTIONS ( wrapper_class 'HolycornRedis'
+        , host '127.0.0.1'
+        , port '6379'
+        , db '0'
+        , prefix 'holycorn_'
+        );

--- a/tests/setups/12.sql
+++ b/tests/setups/12.sql
@@ -1,0 +1,9 @@
+IMPORT FOREIGN SCHEMA holycorn_schema
+FROM SERVER holycorn_server
+INTO holycorn_tables
+OPTIONS ( wrapper_class 'HolycornRedis'
+        , host '127.0.0.1'
+        , port '6379'
+        , db '0'
+        , prefix 'holycorn_'
+        );

--- a/tests/setups/9.4.sql
+++ b/tests/setups/9.4.sql
@@ -1,0 +1,10 @@
+CREATE FOREIGN TABLE holycorn_tables.holycorn_redis_table
+  ( key text
+  , value text
+  )
+  SERVER holycorn_server
+  OPTIONS ( wrapper_class 'HolycornRedis'
+          , host '127.0.0.1'
+          , port '6379'
+          , db '0'
+  );

--- a/tests/setups/9.5.sql
+++ b/tests/setups/9.5.sql
@@ -1,0 +1,9 @@
+IMPORT FOREIGN SCHEMA holycorn_schema
+FROM SERVER holycorn_server
+INTO holycorn_tables
+OPTIONS ( wrapper_class 'HolycornRedis'
+        , host '127.0.0.1'
+        , port '6379'
+        , db '0'
+        , prefix 'holycorn_'
+        );

--- a/tests/setups/9.6.sql
+++ b/tests/setups/9.6.sql
@@ -1,0 +1,9 @@
+IMPORT FOREIGN SCHEMA holycorn_schema
+FROM SERVER holycorn_server
+INTO holycorn_tables
+OPTIONS ( wrapper_class 'HolycornRedis'
+        , host '127.0.0.1'
+        , port '6379'
+        , db '0'
+        , prefix 'holycorn_'
+        );


### PR DESCRIPTION
This commit adds support for `IMPORT FOREIGN SCHEMA` which makes it easy
for developers to define and create foreign tables from Holycorn-based
foreign data wrappers.

Creating a foreign table manually will always be supported, especially
as it allows more custom definitions, but FDW implementers can also
define a method called `import_schema` and return a SQL-string that will
be used to create foreign tables automatically.

Support for Object-Oriented schema definitions is not Open Source (yet?).